### PR TITLE
Define basic templates for common material files

### DIFF
--- a/plantillas/guion.md
+++ b/plantillas/guion.md
@@ -1,0 +1,32 @@
+# {{number}} - {{name}}
+
+## Kahoot de esta sesión
+
+[{{kahoot.name}}]({{kahoot.url}})
+
+## Comunicados importantes
+
+{{news_info}}
+
+### ¿Qué hemos visto hasta ahora?
+
+{{previous_content_info}}
+
+
+### ¿Qué vamos a ver hoy?
+
+{{todays_content_info}}
+
+
+### Espacio para preguntar dudas
+
+{{questions_to_do}}
+
+### Contenido de la sesión
+
+{{session_content_url}}
+
+
+### Comunicados para el siguiente día
+
+{{notices_for_next_sessions}}

--- a/plantillas/proyecto.md
+++ b/plantillas/proyecto.md
@@ -1,0 +1,84 @@
+# Proyecto {{number}}: {{name}}
+
+## Índice
+
+1. Resumen
+1. Objetivos
+1. Casos de uso
+1. Especificaciones
+1. Hitos
+1. Entrega
+1. Consejos
+1. Recursos
+
+
+## Resumen ([TL;DR](https://spanish.stackexchange.com/questions/15317/hay-alg%C3%BAn-equivalente-en-castellano-al-ingl%C3%A9s-tldr))
+
+{{summary}}
+
+
+## Objetivos
+
+{{objectives}}
+
+
+## Caso de uso
+
+{{usecases}}
+
+
+## Especificaciones
+
+{{specifications}}
+
+
+## Hitos
+
+Os proponemos una serie de hitos como sugerencia para dividir las fases de este proyecto. Siguiendo los principios de las metodologías ágiles estableceremos pequeños ciclos iterativos de forma que al final de cada uno de estos generemos valor real, es decir, algo que nos beneficie y sea perceptible por nuestros usuarios (los visitantes de la web):
+
+### {{milestone.number}}. {{milestone.name}}
+
+- {{milestone.duration}}
+- {{milestone.tasks}}
+
+
+## Entrega
+
+El formato de entrega de este proyecto será mediante la subida de este a la plataforma de GitHub. Para subirlo, se creará un repositorio en la organización de Adalab. El nombre del repositorio deberá estar compuesto de las siguientes partes, todo ello separado por guiones:
+- Nombre de la promoción en minúsculas
+- "s" minúscula seguida del número del sprint
+- Nombre del equipo en minúsculas
+
+Por ejemplo, el nombre de la primera promoción de Adalab fue "Ada". Si un grupo realizase un proyecto para el primer sprint y el nombre de ese grupo fuese "Lovelace", el nombre del repositorio debería ser "ada-s1-lovelace".
+
+De manera adicional, se deberá activar "GitHub Pages" en el proyecto para que este pueda ser visualizado como una web, es decir, que en el caso anterior, si alguien introdujese la dirección "adalab.github.io/web-hopper/" en un navegador web, este mostraría la web que se genera con el código del repositorio.
+
+Por último, para acompañar a la entrega del proyecto, el equipo realizará una presentación de 10 minutos mostrando la web y explicando los siguientes puntos:
+
+- Cómo está estructurada la web y el contenido y el por qué de cada cosa
+- Cómo se ha diseñado
+- La estructura del código y las partes más importantes de este (por encima, sin entrar mucho en detalle)
+- Cómo ha sido la organización del equipo, el reparto de tareas y la coordinación a la hora de trabajar todas en el mismo código
+- Cuál de las tareas o los puntos ha sido el que más esfuerzo ha requerido
+- Cuál de las tareas o partes de la web es la que hace que el equipo esté más orgulloso
+
+Al final de esta presentación habrá un turno breve de preguntas, de manera informal, tanto por parte de otras compañeras como por parte de los profesores.
+
+
+## Consejos
+
+### {{advice.title}}
+
+{{advice.info}}
+
+
+## Recursos
+
+Para este proyecto hemos preparado un listado de recursos que os pueden servir de ayuda.
+
+### {{resources_section.name}}
+
+{{resources_section.info}}
+
+- {{resources_section.subsection.name}}
+  - [{{resources_section.subsection.resource.name}}](resources_section.subsection.resource.url) - {{resources_section.subsection.resource.description}}

--- a/plantillas/sesion.md
+++ b/plantillas/sesion.md
@@ -1,0 +1,38 @@
+# {{name}}
+
+## Introducción
+
+{{intro_info}}
+
+
+## ¿Para qué sirve lo que vamos a ver en esta sesión?
+
+{{purpose_info}}
+
+
+## ¿En qué casos se utiliza?
+
+{{usecase_info}}
+
+
+## Recursos externos
+
+### {{resource.name}}
+
+{{resource.description}}
+
+- [{{resource.link_name}}]({{resource.url}})
+
+
+## Resumen de la sesión
+
+{{summary_info}}
+
+
+## Ejercicios
+
+### {{exercise.name}}
+
+{{exercise.info}}
+
+- [{{exercise.link_name}}]({{exercise.url}})

--- a/plantillas/sprint.md
+++ b/plantillas/sprint.md
@@ -1,0 +1,42 @@
+# {{sprint_name}}
+
+{{intro}}
+
+
+## Objetivos
+
+Los objetivos de este bloque, al que de aquí en adelante llamaremos sprint "{{sprint_name}}", serán los siguientes:
+
+- **Objetivos individuales**
+	- Objetivo individual 1
+	- Objetivo individual 2
+- **Objetivos grupales**
+	- Objetivo grupal 1
+  - Objetivo grupal 2
+
+
+## Proyectos
+
+A lo largo de este bloque desarrollaremos un proyecto individual y otro en grupo:
+
+### {{individual_project_name}}
+
+{{individual_project_info}}
+
+### {{group_project_name}}
+
+{{group_project_info}}
+
+
+## ¿Qué vamos a aprender durante este sprint?
+
+{{knowledge_to_learn_info}}
+
+
+## Charlas con voluntarios
+
+Una parte fundamental de nuestro programa son los voluntarios. Estos colaborarán con nosotros para enseñaros aspectos técnicos y profesiones en los cuales tienen gran experiencia. De esta forma el aprendizaje será mucho mejor ya que el tema que os expliquen será algo que ha formado parte de su día a día y, por tanto, dominan.
+
+Las charlas de voluntarios que tendremos durante este sprint son las siguientes:
+- {{first_talk_name}}. {{first_talk_speaker}}
+- {{second_talk_name}}. {{second_talk_speaker}}


### PR DESCRIPTION
He creado una nueva carpeta con plantillas para que utilicemos como estructura de los distintos contenidos que vamos a desarrollar, así es más fácil mantener cierta coherencia en la estructura y sirve como referencia para saber todas las partes que deben componer cualquier archivo.

He creado cuatro plantillas distintas:
- **guion**: para realizar los guiones de la clase. Son archivos que sirven como guía para los profesores y hacen que no se nos olvide nada (a mi me pasaba en las promociones pasadas y esto lo hacía en papel y era de gran ayuda)
- **proyecto**: La estructura básica para un proyecto
- **sesion**: La estructura básica para una sesion tal y como la estructuramos el otro día en la reunión
- **sprint**: El archivo que sirve como introducción a un nuevo sprint y que recoge la introducción, los objetivos y otra información relevante sobre este

He utilizado {{}} porque hay bastantes herramientas que permiten hacer cosas interesantes con esto y en el futuro podríamos incluso utilizar un YAML para el contenido y generar las sesiones con el contenido por un lado y la estructura por otro de tal forma que si en algún momento queremos cambiar algo o añadir algo nuevo sea bastante sencillo, pero eso para la versión 40232.